### PR TITLE
fix: some fixes and experiments [work in progress]

### DIFF
--- a/ciqual/nutrients.py
+++ b/ciqual/nutrients.py
@@ -86,9 +86,9 @@ def setup_ingredients(ingredients):
             ciqual_ingredient = ciqual_ingredients.get(ciqual_code, None)
             if (ciqual_ingredient is None):
                 # Invent a dummy set of nutrients with maximum ranges
-                # TODO: Could use max values that occur in acual data
+                # TODO: Could use max values that occur in actual data
                 for off_id in off_to_ciqual:
-                    ingredient_nutrients[off_id] = {'percent_min': 0, 'percent_max': 100}
+                    ingredient_nutrients[off_id] = {'percent_min': 0, 'percent_max': 0}
             else:
                 for ciqual_key in ciqual_ingredient:
                     nutrient = ciqual_to_off.get(ciqual_key)

--- a/prepare_nutrients.py
+++ b/prepare_nutrients.py
@@ -33,14 +33,22 @@ def assign_weightings(product):
 
     for nutrient_key in computed_nutrients:
         computed_nutrient = computed_nutrients[nutrient_key]
-        product_nutrient = product_nutrients.get(nutrient_key)
+        # Get nutrient value per 100g of product
+        product_nutrient = product_nutrients.get(nutrient_key + '_100g', None)
         if product_nutrient is None:
             computed_nutrient['notes'] = 'Not listed on product'
             continue
 
         computed_nutrient['product_total'] = product_nutrient
+
+        # Energy is derived from other nutrients, so don't use it
         if nutrient_key == 'energy':
             computed_nutrient['notes'] = 'Energy not used for calculation'
+            continue
+
+        # Sodium is computed from salt, so don't use it, to avoid double counting
+        if nutrient_key == 'sodium':
+            computed_nutrient['notes'] = 'Sodium not used for calculation'
             continue
 
         if product_nutrient == 0 and computed_nutrient['unweighted_total'] == 0:
@@ -65,6 +73,7 @@ def assign_weightings(product):
         except Exception as e:
             computed_nutrient['notes'] = e
 
+        computed_nutrient['weighting'] = 1
 
 def prepare_nutrients(product):
     nutrients = {}


### PR DESCRIPTION
Main changes:
- compute percent_estimate for parent ingredients (by summing the quantities of child ingredients), as the metrics will be computed on them if they have specified percent on the products
- use [nutrient]_100g fields, as [nutrient] can be per serving or per 100g
- experimenting with weights of nutrients
- completely remove the nutrient contribution of ingredients without ciqual codes, as having min = 0 and max = 100 for them seems to make the whole nutrient distance not used: the percent of ingredients seeem to be distributed in an equitable way...
e.g. for Nutella:

<!DOCTYPE html>

<html>
<head>
	
	
	<title></title>
	<meta name="generator" content="LibreOffice 7.3.7.2 (Linux)"/>
	<style type="text/css">
		body,div,table,thead,tbody,tfoot,tr,th,td,p { font-family:"Liberation Sans"; font-size:x-small }
		a.comment-indicator:hover + comment { background:#ffd; position:absolute; display:block; border:1px solid black; padding:0.5em;  } 
		a.comment-indicator { background:red; display:inline-block; border:1px solid black; width:0.5em; height:0.5em;  } 
		comment { display:none;  } 
	</style>
	
</head>

<body>

ingredient | ciqual_food_code | ciqual_proxy_food_code | total_percent_estimate | total_difference | number_of_products | number_of_products_where_specified
-- | -- | -- | -- | -- | -- | --
en:fat-reduced-cocoa |   |   | 3,52 | 3,88 | 1 | 1
en:hazelnut-oil | 17210 |   | 14 | 0,977 | 1 | 1
en:palm-oil | 16129 |   | 14 | 0 | 1 | 0
en:skimmed-milk-powder | 19054 |   | 3,52 | 3,08 | 1 | 1
en:soya-lecithin | 42200 |   | 3,52 | 0 | 1 | 0
en:sugar |   | 31016 | 54,4 | 0 | 1 | 0
en:vanillin |   |   | 3,52 | 0 | 1 | 0
en:whey-powder |   |   | 3,52 | 0 | 1 | 0


</body>

</html>
