### PR TITLE
vitamin-b1_unit to vitamin-b1

### DIFF
--- a/ciqual/nutrient_map.csv
+++ b/ciqual/nutrient_map.csv
@@ -17,7 +17,7 @@ potassium,94142,Potassium (mg/100g),mg,,
 monounsaturated-fat,49138,FA mono (g/100g),g,,
 polyunsaturated-fat,49095,FA poly (g/100g),g,,
 alcohol,27268,Alcohol (g/100g),g,,
-vitamin-b1_unit,24952,Vitamin B1 or Thiamin (mg/100g),mg,,
+vitamin-b1,24952,Vitamin B1 or Thiamin (mg/100g),mg,,
 vitamin-pp,24523,Vitamin B3 or Niacin (mg/100g),mg,,A component of B3?
 vitamin-b2,24088,Vitamin B2 or Riboflavin (mg/100g),mg,,
 vitamin-b6,16923,Vitamin B6 (mg/100g),mg,,


### PR DESCRIPTION
In the nutrient map, the OFF key for Vitamin B1 or Thiamin (mg/100g) is set to vitamin-b1_unit, while I assume it should be vitamin-b1.