### PR TITLE
feat: add max constraints on some high sugar/salt/fat ingredients

### DIFF
--- a/recipe_estimator.py
+++ b/recipe_estimator.py
@@ -83,6 +83,46 @@ def add_to_relative_constraint(solver, relative_constraint, ingredient_numvar, c
         print("relative_constraint:", relative_constraint.name(), ingredient_numvar['ingredient']['id'], coefficient)
         relative_constraint.SetCoefficient(ingredient_numvar['numvar'], coefficient)
 
+# add maximum quantity constraints on some ingredients like en:salt (5g) and en:flavouring (1g)
+def add_maximum_quantity_constraints(solver, ingredient_numvars):
+    for ingredient_numvar in ingredient_numvars:
+        ingredient = ingredient_numvar['ingredient']
+        if ('child_numvars' in ingredient_numvar):
+            add_maximum_quantity_constraints(solver, ingredient_numvar['child_numvars'])
+        else:
+            if ingredient['id'] == 'en:salt' or ingredient['id'] == 'en:sea-salt':
+                salt_constraint = solver.Constraint(0, 5)
+                salt_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
+            if ingredient['id'] == 'en:flavouring':
+                flavouring_constraint = solver.Constraint(0, 1)
+                flavouring_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
+            # if the ingredient is an additive (id starts with "en:e" + digits) then we set a maximum quantity of 1g
+            if ingredient['id'].startswith('en:e'):
+                additive_constraint = solver.Constraint(0, 1)
+                additive_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
+
+# add max limits on ingredients en:salt and en:sugar based on the sugars and salt nutrition facts of the product
+def add_maximum_limits_on_salt_and_sugar(solver, ingredient_numvars, salt_constraint, sugars_constraint, fat_constraint):
+    for ingredient_numvar in ingredient_numvars:
+        ingredient = ingredient_numvar['ingredient']
+        if ('child_numvars' in ingredient_numvar):
+            add_maximum_limits_on_salt_and_sugar(solver, ingredient_numvar['child_numvars'], salt_constraint, sugars_constraint, fat_constraint)
+        else:
+            if ingredient['id'] == 'en:salt' or ingredient['id'] == 'en:sea-salt':
+                salt_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
+            if ingredient['id'] == 'en:sugar' or ingredient['id'] == 'en:cane-sugar':
+                sugars_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
+            # oils: ingredient id ending with -oil, en:cocoa-butter
+            if ingredient['id'].endswith('-oil') or ingredient['id'] == 'en:cocoa-butter':
+                fat_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
+            # butter: min 80% fat
+            if ingredient['id'] == 'en:butter':
+                fat_constraint.SetCoefficient(ingredient_numvar['numvar'], 0.8)
+            # butterfat: 90% fat
+            if ingredient['id'] == 'en:butterfat':
+                fat_constraint.SetCoefficient(ingredient_numvar['numvar'], 0.9)
+
+
 # For each ingredient, get the quantity estimate from the solver (for leaf ingredients)
 # or sum the quantity estimates of the child ingredients (for non-leaf ingredients)
 def get_quantity_estimate(ingredient_numvars):
@@ -170,6 +210,19 @@ def estimate_recipe(product):
     # add_relative_constraints_on_ingredients(solver, ingredient_numvars)
 
     add_relative_constraints_on_ingredients(solver, None, ingredient_numvars)
+
+    add_maximum_quantity_constraints(solver, ingredient_numvars)
+
+    salt = product['nutriments'].get('salt_100g', 0)
+    salt_constraint = solver.Constraint(0, salt)
+
+    sugar = product['nutriments'].get('sugars_100g', 0)
+    sugar_constraint = solver.Constraint(0, sugar)
+    
+    fat = product['nutriments'].get('fat_100g', 0)
+    fat_constraint = solver.Constraint(0, fat)
+
+    add_maximum_limits_on_salt_and_sugar(solver, ingredient_numvars, salt_constraint, sugar_constraint, fat_constraint)
 
     objective = solver.Objective()
     for nutrient_key in nutrients:

--- a/recipe_estimator.py
+++ b/recipe_estimator.py
@@ -93,12 +93,12 @@ def add_maximum_quantity_constraints(solver, ingredient_numvars):
             if ingredient['id'] == 'en:salt' or ingredient['id'] == 'en:sea-salt':
                 salt_constraint = solver.Constraint(0, 5)
                 salt_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
-            if ingredient['id'] == 'en:flavouring':
-                flavouring_constraint = solver.Constraint(0, 1)
+            if ingredient['id'] == 'en:flavouring' or ingredient['id'] == 'en:natural-flavouring':
+                flavouring_constraint = solver.Constraint(0, 2)
                 flavouring_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
             # if the ingredient is an additive (id starts with "en:e" + digits) then we set a maximum quantity of 1g
             if ingredient['id'].startswith('en:e'):
-                additive_constraint = solver.Constraint(0, 1)
+                additive_constraint = solver.Constraint(0, 2)
                 additive_constraint.SetCoefficient(ingredient_numvar['numvar'], 1)
 
 # add max limits on ingredients en:salt and en:sugar based on the sugars and salt nutrition facts of the product


### PR DESCRIPTION
adding constraints on the maximum of specific ingredients that have known absolute minimums for specific nutrients like sugar, salt, fat

getting better results:

baseline: 23.39 average difference
salt < 5: 23.28
+ en:flavouring < 1: 23.29
+ additives < 1g: 22.92
+ max limit on sugars and salt (individual ingredient limit): 22.76
+ en:cane-sugar: 22.71
better function for max salt, sugars (limit on combined content of ingredients contributing sugar): 22.69
+ oils: 22.66
+ butter: 22.64
+ btterfat: 22.64
+ cocoa butter: 22.63

approach can be generalized for all ingredients:
- the sum of the absolute minimums of sugars/salt/fat of all ingredients must be inferior to the total nutrient value
- the sum of the absolute maximums of sugars/salt/fat of all ingredients must be greater to the total nutrient value
