### PR TITLE
fix: add a use_simple_estimates option to cvxpy

### DIFF
--- a/frontend/src/Recipe.tsx
+++ b/frontend/src/Recipe.tsx
@@ -86,7 +86,7 @@ export default function Recipe({product}: RecipeProps) {
       setPenalties(resultingProduct.recipe_estimator.penalties)
     }
     fetchData();
-  }, [algorithm]);
+  }, [algorithm, useSimpleEstimates]);
 
   const refreshPenalties = useCallback((product: any) => {
     async function fetchData() {

--- a/frontend/src/Recipe.tsx
+++ b/frontend/src/Recipe.tsx
@@ -69,13 +69,14 @@ export default function Recipe({product}: RecipeProps) {
   const [nutrients, setNutrients] = useState<any>();
   const [penalties, setPenalties] = useState<any>();
   const [algorithm, setAlgorithm] = useState<string>(DEFAULT_ALGORITHM);
+  const [useSimpleEstimates, setUseSimpleEstimates] = useState(false);
 
   const getRecipe = useCallback((product: any) => {
     if (!product || !product.ingredients)
       return;
     async function fetchData() {
       setIngredients(null);
-      const results = await (await fetch(`${API_PATH}api/v3/${algorithm}`, {method: 'POST', body: JSON.stringify({product: product, options: {debug: true}})})).json();
+      const results = await (await fetch(`${API_PATH}api/v3/${algorithm}`, {method: 'POST', body: JSON.stringify({product: product, options: {debug: true, use_simple_estimates: useSimpleEstimates}})})).json();
       const resultingProduct = results.product;
       setIngredients(resultingProduct.ingredients);
       setNutrients(Object.fromEntries(
@@ -217,21 +218,38 @@ export default function Recipe({product}: RecipeProps) {
               <Typography>{product.ingredients_text}</Typography>
             </TableCell>
             <TableCell>
-              <FormControl variant="standard">
-                <InputLabel id="algorithm-label">Algorithm:</InputLabel>
-                <br/>
-                <Select
-                  labelId="algorithm-label"
-                  value={algorithm}
-                  label="Algorithm"
-                  onChange={(event) => recalculateRecipe(event.target.value)}
-                >
-                  {Object.entries(algorithms).map((entry) => (
-                    <MenuItem value={entry[0]}>{entry[1]}</MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </TableCell>
+               <FormControl variant="standard">
+                 <InputLabel id="algorithm-label">Algorithm:</InputLabel>
+                 <br/>
+                 <Select
+                   labelId="algorithm-label"
+                   value={algorithm}
+                   label="Algorithm"
+                   onChange={(event) => recalculateRecipe(event.target.value)}
+                 >
+                   {Object.entries(algorithms).map((entry) => (
+                     <MenuItem value={entry[0]}>{entry[1]}</MenuItem>
+                   ))}
+                 </Select>
+               </FormControl>
+             </TableCell>
+             {algorithm === 'estimate_recipe_cvxpy' && (
+               <TableCell>
+                 <FormControl variant="standard">
+                   <InputLabel id="use-simple-estimates-label">Use simple estimates:</InputLabel>
+                   <br/>
+                   <Select
+                     labelId="use-simple-estimates-label"
+                     value={useSimpleEstimates ? "true" : "false"}
+                     label="Use simple estimates"
+                     onChange={(event) => setUseSimpleEstimates(event.target.value === "true")}
+                   >
+                     <MenuItem value="false">No</MenuItem>
+                     <MenuItem value="true">Yes</MenuItem>
+                   </Select>
+                 </FormControl>
+               </TableCell>
+             )}
             <TableCell>
               <Table size='small' sx={{'& .MuiTableCell-sizeSmall': {padding: '1px 4px'}}}>
                 <TableBody>

--- a/recipe_estimator/main.py
+++ b/recipe_estimator/main.py
@@ -115,12 +115,12 @@ def _product_response(product, options=None):
 
 # generic function to use in estimate_recipe_* endpoints that only differ by the estimation method used
 # read the product and options from the request, prepare the product, call the estimation function and return the response
-async def estimate_recipe_generic(request: Request, estimation_function):
+async def estimate_recipe_generic(request: Request, estimation_function, **kwargs):
     product, options, error_response = await _read_product(request)
     if error_response:
         return error_response
     prepare_product(product)
-    estimation_function(product)
+    estimation_function(product, **kwargs)
     if not bool(options.get("debug")):
         remove_temporary_ingredients_fields(product.get("ingredients", []))
     return _product_response(product, options)
@@ -157,7 +157,20 @@ async def recipe(request: Request):
 
 @app.post("/api/v3/estimate_recipe_cvxpy")
 async def recipe(request: Request):
-    return await estimate_recipe_generic(request, estimate_recipe_cvxpy)
+    errors = []
+    warnings = []
+    try:
+        payload = await request.json()
+    except Exception:
+        add_error(errors, "body", "invalid_json", "Invalid JSON")
+        return _failure_response(errors, warnings)
+
+    if not isinstance(payload, dict):
+        add_error(errors, "body", "invalid_json", "Invalid JSON")
+        return _failure_response(errors, warnings)
+
+    use_simple = payload.get("options", {}).get("use_simple_estimates", False)
+    return await estimate_recipe_generic(request, estimate_recipe_cvxpy, use_simple_estimates=use_simple)
 
 @app.post("/api/v3/get_penalties")
 async def recipe(request: Request):

--- a/recipe_estimator/product.py
+++ b/recipe_estimator/product.py
@@ -45,10 +45,15 @@ def get_product(id):
         headers={
             "User-Agent": "recipe-estimator/0.1 (recipe-estimator.openfoodfacts.org)"
         },
-    ).json()
-    if not "product" in response:
+    )
+    try:
+        data = response.json()
+    except ValueError:
         return {}
 
-    product = response["product"]
+    if not isinstance(data, dict) or "product" not in data:
+        return {}
+
+    product = data["product"]
     fix_ingredients(product["ingredients"])
     return product

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -180,7 +180,7 @@ def set_percentages(solution_x, ingredient_vars, product_total_quantity):
     return index, total_mixing_bowl_quantity, total_original_quantity
 
 
-def estimate_recipe(product):
+def estimate_recipe(product, use_simple_estimates=False):
     current = time.perf_counter()
     leaf_ingredient_count = prepare_nutrients(product, True)
     ingredients = product["ingredients"]
@@ -254,7 +254,7 @@ def estimate_recipe(product):
         # the ingredient nutrients are greater than the product nutrients
         # But it didn't offer any significant improvement
 
-    try_nutrients = percent_unknown < 10 and len(leaf_ingredients[0]["nutrients"])
+    try_nutrients = False if use_simple_estimates else (percent_unknown < 10 and len(leaf_ingredients[0]["nutrients"]))
 
     # Don't bother with the nutrient approach if the first ingredient is unknown or too many others are unknown
     objectives = nutrient_objectives if try_nutrients else simple_objectives


### PR DESCRIPTION
This PR adds a use_simple_estimates option to the cvxpy algorithm, so that we can have a baseline to improve it, without the nutrients optimization to be triggered if the % of ingredients without nutrients is above the threshold.

Results are actually quite good:

option false: (normal cvxpy)

```
Results summary for test set fr-1000-some-specified-popular:
Total difference: 23551.21
Total variance: 653096.29
Number of products: 1000
Average difference: 23.55
Average variance: 653.1
All ciqual test set total difference: 2656.57
All ciqual test set total variance: 128789.04
All ciqual test set number of products: 128
All ciqual test set average difference: 20.75
All ciqual test set average variance: 1006.0
Percent estimate with ciqual_food_code: 48.7
Percent estimate with ciqual_proxy_food_code: 34.7
Percent estimate with ciqual or ciqual_proxy_food_code: 83.4
```


option true: (simple estimates)

```
Results summary for test set fr-1000-some-specified-popular:
Total difference: 23712.5
Total variance: 564826.68
Number of products: 1000
Average difference: 23.71
Average variance: 564.8
All ciqual test set total difference: 2322.76
All ciqual test set total variance: 51321.41
All ciqual test set number of products: 128
All ciqual test set average difference: 18.15
All ciqual test set average variance: 400.9
Percent estimate with ciqual_food_code: 46.7
Percent estimate with ciqual_proxy_food_code: 35.2
Percent estimate with ciqual or ciqual_proxy_food_code: 82.0
```

Note: most of the code generated with Kilo and free models.