### PR TITLE
fix: add salt/sugar/fat + small quantity ingredient in cvxpy simple estimates

### DIFF
--- a/frontend/src/Recipe.tsx
+++ b/frontend/src/Recipe.tsx
@@ -86,7 +86,7 @@ export default function Recipe({product}: RecipeProps) {
       setPenalties(resultingProduct.recipe_estimator.penalties)
     }
     fetchData();
-  }, [algorithm]);
+  }, [algorithm, useSimpleEstimates]);
 
   const refreshPenalties = useCallback((product: any) => {
     async function fetchData() {

--- a/frontend/src/Recipe.tsx
+++ b/frontend/src/Recipe.tsx
@@ -69,13 +69,14 @@ export default function Recipe({product}: RecipeProps) {
   const [nutrients, setNutrients] = useState<any>();
   const [penalties, setPenalties] = useState<any>();
   const [algorithm, setAlgorithm] = useState<string>(DEFAULT_ALGORITHM);
+  const [useSimpleEstimates, setUseSimpleEstimates] = useState(false);
 
   const getRecipe = useCallback((product: any) => {
     if (!product || !product.ingredients)
       return;
     async function fetchData() {
       setIngredients(null);
-      const results = await (await fetch(`${API_PATH}api/v3/${algorithm}`, {method: 'POST', body: JSON.stringify({product: product, options: {debug: true}})})).json();
+      const results = await (await fetch(`${API_PATH}api/v3/${algorithm}`, {method: 'POST', body: JSON.stringify({product: product, options: {debug: true, use_simple_estimates: useSimpleEstimates}})})).json();
       const resultingProduct = results.product;
       setIngredients(resultingProduct.ingredients);
       setNutrients(Object.fromEntries(
@@ -217,21 +218,38 @@ export default function Recipe({product}: RecipeProps) {
               <Typography>{product.ingredients_text}</Typography>
             </TableCell>
             <TableCell>
-              <FormControl variant="standard">
-                <InputLabel id="algorithm-label">Algorithm:</InputLabel>
-                <br/>
-                <Select
-                  labelId="algorithm-label"
-                  value={algorithm}
-                  label="Algorithm"
-                  onChange={(event) => recalculateRecipe(event.target.value)}
-                >
-                  {Object.entries(algorithms).map((entry) => (
-                    <MenuItem value={entry[0]}>{entry[1]}</MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </TableCell>
+               <FormControl variant="standard">
+                 <InputLabel id="algorithm-label">Algorithm:</InputLabel>
+                 <br/>
+                 <Select
+                   labelId="algorithm-label"
+                   value={algorithm}
+                   label="Algorithm"
+                   onChange={(event) => recalculateRecipe(event.target.value)}
+                 >
+                   {Object.entries(algorithms).map((entry) => (
+                     <MenuItem value={entry[0]}>{entry[1]}</MenuItem>
+                   ))}
+                 </Select>
+               </FormControl>
+             </TableCell>
+             {algorithm === 'estimate_recipe_cvxpy' && (
+               <TableCell>
+                 <FormControl variant="standard">
+                   <InputLabel id="use-simple-estimates-label">Use simple estimates:</InputLabel>
+                   <br/>
+                   <Select
+                     labelId="use-simple-estimates-label"
+                     value={useSimpleEstimates ? "true" : "false"}
+                     label="Use simple estimates"
+                     onChange={(event) => setUseSimpleEstimates(event.target.value === "true")}
+                   >
+                     <MenuItem value="false">No</MenuItem>
+                     <MenuItem value="true">Yes</MenuItem>
+                   </Select>
+                 </FormControl>
+               </TableCell>
+             )}
             <TableCell>
               <Table size='small' sx={{'& .MuiTableCell-sizeSmall': {padding: '1px 4px'}}}>
                 <TableBody>

--- a/recipe_estimator/main.py
+++ b/recipe_estimator/main.py
@@ -115,12 +115,12 @@ def _product_response(product, options=None):
 
 # generic function to use in estimate_recipe_* endpoints that only differ by the estimation method used
 # read the product and options from the request, prepare the product, call the estimation function and return the response
-async def estimate_recipe_generic(request: Request, estimation_function):
+async def estimate_recipe_generic(request: Request, estimation_function, **kwargs):
     product, options, error_response = await _read_product(request)
     if error_response:
         return error_response
     prepare_product(product)
-    estimation_function(product)
+    estimation_function(product, **kwargs)
     if not bool(options.get("debug")):
         remove_temporary_ingredients_fields(product.get("ingredients", []))
     return _product_response(product, options)
@@ -157,7 +157,20 @@ async def recipe(request: Request):
 
 @app.post("/api/v3/estimate_recipe_cvxpy")
 async def recipe(request: Request):
-    return await estimate_recipe_generic(request, estimate_recipe_cvxpy)
+    errors = []
+    warnings = []
+    try:
+        payload = await request.json()
+    except Exception:
+        add_error(errors, "body", "invalid_json", "Invalid JSON")
+        return _failure_response(errors, warnings)
+
+    if not isinstance(payload, dict):
+        add_error(errors, "body", "invalid_json", "Invalid JSON")
+        return _failure_response(errors, warnings)
+
+    use_simple = payload.get("options", {}).get("use_simple_estimates", False)
+    return await estimate_recipe_generic(request, estimate_recipe_cvxpy, use_simple_estimates=use_simple)
 
 @app.post("/api/v3/get_penalties")
 async def recipe(request: Request):

--- a/recipe_estimator/product.py
+++ b/recipe_estimator/product.py
@@ -45,10 +45,15 @@ def get_product(id):
         headers={
             "User-Agent": "recipe-estimator/0.1 (recipe-estimator.openfoodfacts.org)"
         },
-    ).json()
-    if not "product" in response:
+    )
+    try:
+        data = response.json()
+    except ValueError:
         return {}
 
-    product = response["product"]
+    if not isinstance(data, dict) or "product" not in data:
+        return {}
+
+    product = data["product"]
     fix_ingredients(product["ingredients"])
     return product

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -108,8 +108,9 @@ def add_ingredient_constraints(
 
 
 def estimate_percentages(
-    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown=0, constraints=None, product_nutrients=None, is_first_product_ingredient=True, expressions=None
+    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown=0, constraints=None, product_nutrients=None, is_first_product_ingredient=True, expressions=None, custom_estimates=None
 ):
+    # If called without custom estimates then we use a power-law series to estimate the percentages of each ingredient based on its position in the list of ingredients
     # Each ingredient quantity = a * n ^ p
     # where p is the POWER constant, n is the ingredient number and a is the percentage of the first ingredient
     # We work out a by adding up all the results of the series with a = 1 and then factor a so that the total adds up to 100% (total)
@@ -128,7 +129,10 @@ def estimate_percentages(
     raw_sum = sum([(n + 1.0) ** POWER for n in range(num_ingredients)])
     a = total / raw_sum
     for n, ingredient in enumerate(ingredients):
-        estimate = round(a * (n + 1.0) ** POWER, 2)
+        if custom_estimates is not None:
+            estimate = custom_estimates[index]
+        else:
+            estimate = round(a * (n + 1.0) ** POWER, 2)
 
         if "ingredients" in ingredient and len(ingredient["ingredients"]) > 0:
             index, percent_unknown = estimate_percentages(
@@ -141,9 +145,10 @@ def estimate_percentages(
                 index,
                 percent_unknown,
                 constraints,
-                nutriments,
+                product_nutrients,
                 is_first_product_ingredient and n == 0,
-                expressions
+                expressions,
+                custom_estimates
             )
         else:
             # If ingredient has no nutrient information then add an objective to keep close to the estimate
@@ -186,16 +191,16 @@ def estimate_percentages(
     # If we are at the top level and we have nutritional information for the product
     # we add constraints to keep the total salt, sugar and fat below the product's nutritional information
     # We do this because processing (e.g. evaporation) should not reduce the total amount of salt, sugar or fat in the product
-    if is_top_level and constraints is not None and nutriments is not None:
-        salt = nutriments.get('salt_100g')
+    if is_top_level and constraints is not None and product_nutrients is not None:
+        salt = product_nutrients.get('salt_100g')
         if salt is not None:
             constraints.append(expressions['salt'] <= ensure_float(salt))
 
-        sugars = nutriments.get('sugars_100g')
+        sugars = product_nutrients.get('sugars_100g')
         if sugars is not None:
             constraints.append(expressions['sugars'] <= ensure_float(sugars))
 
-        fat = nutriments.get('fat_100g')
+        fat = product_nutrients.get('fat_100g')
         if fat is not None:
             constraints.append(expressions['fat'] <= ensure_float(fat))
 
@@ -290,73 +295,96 @@ def estimate_recipe(product, use_simple_estimates=False):
     
     # Need an np.array in the matrix multiplication below
     ingredients_nutrients = np.array(ingredients_nutrients)
-    nutrient_objectives = []
-    simple_objectives = []
-    simple_estimates = []
 
-    # Add objective to keep unknown ingredients close to the inverse power series
-    # simple_objectives does this for all ingredients
-    _, percent_unknown = estimate_percentages(ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, constraints=constraints, nutriments=product.get('nutriments', {}))
+    # Pass 1A: Run estimate_percentages to get initial estimates for the ingredient quantities and objectives
+    # Initial estimates are based on a power-law series.
+    nutrient_objectives1 = []
+    simple_objectives1 = []
+    simple_estimates1 = []
+    _, _ = estimate_percentages(
+        ingredient_quantities, nutrient_objectives1, simple_objectives1, ingredients, simple_estimates1,
+        constraints=constraints, product_nutrients=product.get('nutriments', {})
+    )
 
-    # Main objective to match ingredient nutrients to product nutrients
-    if product_nutrients:
+    # Pass 1B: Run the solver with simple objectives
+
+    evaporation_cost = EVAPORATION_COST * cp.square(sum(ingredient_quantities) - 100)
+    objectives1 = list(simple_objectives1)
+    objectives1.append(evaporation_cost)
+
+    prob1 = cp.Problem(cp.Minimize(sum(objectives1)), constraints)
+    prob1.solve()
+
+    pass1_solution = ingredient_quantities.value if prob1.status == cp.OPTIMAL else simple_estimates1
+
+    # Pass 2A: Run estimate_percentages again to get updated objectives + new percent unknown based on the solution from pass 1B (if we have one)
+
+    nutrient_objectives2 = []
+    simple_objectives2 = []
+    simple_estimates2 = []
+
+    custom_estimates = pass1_solution if pass1_solution is not None else None
+
+    _, percent_unknown2 = estimate_percentages(
+        ingredient_quantities, nutrient_objectives2, simple_objectives2, ingredients, simple_estimates2,
+        custom_estimates=custom_estimates,
+        constraints=constraints, product_nutrients=product.get('nutriments', {})
+    )
+
+    # Pass 2B (optional): If we have nutrient information for the product and the ingredients,
+    # and if the percent unknown is low, then we try to solve with nutrient objectives
+
+    try_nutrients = False if use_simple_estimates else (percent_unknown2 < 10 and len(leaf_ingredients[0]["nutrients"]))
+
+    final_solution = pass1_solution
+    final_prob = prob1
+    nutrient_variance_value = None
+
+    if try_nutrients and product_nutrients:
         residual = ingredients_nutrients @ ingredient_quantities - product_nutrients
         nutrient_variance = cp.sum(nutrient_weightings @ cp.square(residual))
-        nutrient_objectives.append(nutrient_variance)
+        nutrient_objectives2.append(nutrient_variance)
 
-        # Tried adding a penalty if not all ingredients are known to penalize results where
-        # the ingredient nutrients are greater than the product nutrients
-        # But it didn't offer any significant improvement
+        objectives2 = list(nutrient_objectives2)
+        objectives2.append(evaporation_cost)
 
-    try_nutrients = False if use_simple_estimates else (percent_unknown < 10 and len(leaf_ingredients[0]["nutrients"]))
+        prob2 = cp.Problem(cp.Minimize(sum(objectives2)), constraints)
+        prob2.solve()
 
-    # Don't bother with the nutrient approach if the first ingredient is unknown or too many others are unknown
-    objectives = nutrient_objectives if try_nutrients else simple_objectives
-    
-    # Get the ingredients to add up to close to 100g, which effectively adds a cost for evaporation.
-    # Could potentially adjust the weighting here depending on the food category
-    evaporation_cost = EVAPORATION_COST * cp.square(sum(ingredient_quantities) - 100)
-    objectives.append(evaporation_cost)
-
-    objective = cp.Minimize(sum(objectives))
-    prob = cp.Problem(objective, constraints)
-    prob.solve()
-
-    if product_nutrients:
-        if prob.status == cp.OPTIMAL:
+        if prob2.status == cp.OPTIMAL:
             nutrient_variance_value = nutrient_variance.value.item()
             recipe_estimator["nutrient_variance"] = nutrient_variance_value
 
-        # If nutrient variance is too much then try again with the simple approach
-        if try_nutrients and (prob.status != cp.OPTIMAL or nutrient_variance_value > 2500):
-            objectives = simple_objectives
-            objective = cp.Minimize(sum(objectives))
-            prob = cp.Problem(objective, constraints)
-            prob.solve()
-            if prob.status == cp.OPTIMAL:
-                recipe_estimator["nutrient_variance_simple"] = nutrient_variance.value.item()
+            if nutrient_variance_value <= 2500:
+                final_solution = ingredient_quantities.value
+                final_prob = prob2
+            else:
+                final_solution = pass1_solution
+                final_prob = prob1
+        else:
+            final_solution = pass1_solution
+            final_prob = prob1
 
-    solution_x = ingredient_quantities.value if prob.status == cp.OPTIMAL else simple_estimates
-        
-    # In the UK/EU the percentage is the weight of raw product needed to produce 100g divided by the final weight (100g)
-    # In the US it is the weight of raw ingredient divided by the total weight of all raw ingredients
-    product_total_quantity = sum(solution_x) if recipe_estimator.get('might_be_us') else 100
+    if try_nutrients and product_nutrients and final_prob is prob1 and prob1.status == cp.OPTIMAL:
+        product_nutrients_arr = np.array(product_nutrients)
+        nutrient_weightings_arr = np.array(nutrient_weightings)
+        residual1 = ingredients_nutrients @ np.array(pass1_solution) - product_nutrients_arr
+        recipe_estimator["nutrient_variance_simple"] = float(np.sum(nutrient_weightings_arr @ np.square(residual1)))
 
-    set_percentages(solution_x, ingredient_vars, product_total_quantity)
+    if final_solution is not None:
+        product_total_quantity = sum(final_solution) if recipe_estimator.get('might_be_us') else 100
 
-    # Calculate objective function so we can compare with SciPy
-    quantities = np.array(
-        [float(ingredient["quantity_estimate"]) for ingredient in leaf_ingredients]
-    )
-    [_, _, args] = get_objective_function_args(product)
-    objective_function(quantities, *args)
-    recipe_estimator["penalties"] = args[0]
+        set_percentages(final_solution, ingredient_vars, product_total_quantity)
 
-    recipe_estimator["status"] = 0 # TODO: Should probably have different status codes for different failure modes, e.g. not optimal vs unbounded vs infeasible
-    recipe_estimator["status_message"] = prob.status
+        quantities = np.array(
+            [float(ingredient["quantity_estimate"]) for ingredient in leaf_ingredients]
+        )
+        [_, _, args] = get_objective_function_args(product)
+        objective_function(quantities, *args)
+        recipe_estimator["penalties"] = args[0]
+
+    recipe_estimator["status"] = 0
+    recipe_estimator["status_message"] = final_prob.status
     recipe_estimator["time"] = round(time.perf_counter() - current, 2)
-
-    # Tried re-running the solver multiple times to get the minimum and maximum of each ingredient
-    # But it had a significant performance penalty
 
     return

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -23,12 +23,22 @@ def get_ingredient_range(ingredient_percentage):
 
 def add_ingredient_constraints(
     ingredients,
+    nutrients,
     constraints,
     leaf_ingredients,
     ingredient_quantities,
     water_proportions,
     ingredient_vars,
+    nutrients_from_ingredients = None,
 ):
+    is_top_level = nutrients_from_ingredients is None
+    if is_top_level:
+        nutrients_from_ingredients = {
+            'salt': cp.Constant(0),
+            'sugars': cp.Constant(0),
+            'fat': cp.Constant(0),
+        }
+
     previous_ingredient_mixing_bowl_weight = None
     total_mixing_bowl_weight = []
     for ingredient in ingredients:
@@ -46,11 +56,13 @@ def add_ingredient_constraints(
             ingredient_var["ingredients"] = []
             my_mixing_bowl_weight = add_ingredient_constraints(
                 ingredient["ingredients"],
+                nutrients,
                 constraints,
                 leaf_ingredients,
                 ingredient_quantities,
                 water_proportions,
                 ingredient_var["ingredients"],
+                nutrients_from_ingredients,
             )
             # Keep a note of how many child ingredients make up the total for this parent ingredient
             last_child_index = len(leaf_ingredients)
@@ -98,111 +110,109 @@ def add_ingredient_constraints(
                 ])
                 my_mixing_bowl_weight.append(-pre_mixing_bowl_water_loss)
 
+            ingredient_id = ingredient.get("id", "")
+
+            # Add constraint for flavour ingredients and food additives, except for first leaf ingredient
+            if my_index > 0:
+                if "flavour" in ingredient_id or (ingredient_id.startswith("en:e") and len(ingredient_id) > 4 and ingredient_id[4].isdigit()):
+                    constraints.append(my_quantity <= 2.0)
+
+            # If we are certain the ingredient contains a minimum amount of salt, sugar or fat
+            # we add it to the expressions so that we can add constraints to keep the total below the product's nutritional information
+            if ingredient_id == 'en:salt' or ingredient_id.endswith('-salt'):
+                nutrients_from_ingredients['salt'] += my_quantity
+            elif ingredient_id == 'en:sugar' or ingredient_id.endswith('-sugar'):
+                nutrients_from_ingredients['sugars'] += my_quantity
+            elif ingredient_id == 'en:honey' or ingredient_id.endswith('-honey'):
+                nutrients_from_ingredients['sugars'] += 0.6 * my_quantity
+            elif ingredient_id.endswith('-oil') or ingredient_id == 'en:cocoa-butter':
+                nutrients_from_ingredients['fat'] += my_quantity
+            elif ingredient_id.endswith('-fat'):
+                nutrients_from_ingredients['fat'] += 0.8 * my_quantity
+            elif ingredient_id == 'en:butter':
+                nutrients_from_ingredients['fat'] += 0.8 * my_quantity
+            elif ingredient_id == 'en:butterfat':
+                nutrients_from_ingredients['fat'] += 0.9 * my_quantity
+
         if previous_ingredient_mixing_bowl_weight and my_mixing_bowl_weight:
             constraints.append(sum(previous_ingredient_mixing_bowl_weight) >= sum(my_mixing_bowl_weight))
 
         total_mixing_bowl_weight.extend(my_mixing_bowl_weight)
         previous_ingredient_mixing_bowl_weight = my_mixing_bowl_weight
 
+    # If we are at the top level and we have nutritional information for the product
+    # we add constraints to keep the total salt, sugar and fat below the product's nutritional information
+    # We do this because processing (e.g. evaporation) should not reduce the total amount of salt, sugar or fat in the product
+    if is_top_level and constraints is not None and nutrients is not None:
+        salt = nutrients.get('salt')
+        if salt is not None:
+            constraints.append(nutrients_from_ingredients['salt'] <= ensure_float(salt))
+
+        sugars = nutrients.get('sugars')
+        if sugars is not None:
+            constraints.append(nutrients_from_ingredients['sugars'] <= ensure_float(sugars))
+
+        fat = nutrients.get('fat')
+        if fat is not None:
+            constraints.append(nutrients_from_ingredients['fat'] <= ensure_float(fat))
+
     return total_mixing_bowl_weight
 
 
 def estimate_percentages(
-    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown=0, constraints=None, product_nutrients=None, is_first_product_ingredient=True, expressions=None, custom_estimates=None
+    ingredient_quantities,
+    nutrient_optimization_objectives,
+    simple_optimization_objectives,
+    ingredients,
+    initial_estimates,
+    total=100.0,
+    index=0,
+    percent_unknown=0,
 ):
-    # If called without custom estimates then we use a power-law series to estimate the percentages of each ingredient based on its position in the list of ingredients
+    # If called with a total then we use a power-law series to estimate the percentages of each ingredient based on its position in the list of ingredients
     # Each ingredient quantity = a * n ^ p
     # where p is the POWER constant, n is the ingredient number and a is the percentage of the first ingredient
     # We work out a by adding up all the results of the series with a = 1 and then factor a so that the total adds up to 100% (total)
+    # The initial_estimates array is then populated with these values. If no total is supplied we assume initial_estimates has already been populated.
     num_ingredients = len(ingredients)
     if num_ingredients < 1:
         return 0, 100
 
-    is_top_level = expressions is None
-    if is_top_level:
-        expressions = {
-            'salt': cp.Constant(0),
-            'sugars': cp.Constant(0),
-            'fat': cp.Constant(0),
-        }
+    if total is not None:
+        raw_sum = sum([(n + 1.0) ** POWER for n in range(num_ingredients)])
+        a = total / raw_sum
 
-    raw_sum = sum([(n + 1.0) ** POWER for n in range(num_ingredients)])
-    a = total / raw_sum
     for n, ingredient in enumerate(ingredients):
-        if custom_estimates is not None:
-            estimate = custom_estimates[index]
+        if total is None:
+            initial_estimate = initial_estimates[index]
         else:
-            estimate = round(a * (n + 1.0) ** POWER, 2)
+            initial_estimate = round(a * (n + 1.0) ** POWER, 2)
 
         if "ingredients" in ingredient and len(ingredient["ingredients"]) > 0:
             index, percent_unknown = estimate_percentages(
                 ingredient_quantities,
-                nutrient_objectives,
-                simple_objectives,
+                nutrient_optimization_objectives,
+                simple_optimization_objectives,
                 ingredient["ingredients"],
-                simple_estimates,
-                estimate,
+                initial_estimates,
+                initial_estimate if total is not None else None,
                 index,
                 percent_unknown,
-                constraints,
-                product_nutrients,
-                is_first_product_ingredient and n == 0,
-                expressions,
-                custom_estimates
             )
         else:
-            # If ingredient has no nutrient information then add an objective to keep close to the estimate
+            # If ingredient has no nutrient information then add an objective to keep close to the initial estimate
             if len(ingredient["nutrients"]) == 0:
-                percent_unknown += estimate
-                nutrient_objectives.append(
+                percent_unknown += initial_estimate
+                nutrient_optimization_objectives.append(
                     UNKNOWN_INGREDIENT_WEIGHTING
-                    * cp.square(ingredient_quantities[index] - estimate)
+                    * cp.square(ingredient_quantities[index] - initial_estimate)
                 )
-            # Simple objectives are used if we find that going by nutrients doesn't work
-            simple_objectives.append(cp.square(ingredient_quantities[index] - estimate))
-            simple_estimates.append(estimate)
+            # All ingredients aim to be as close as possible to the initial estimate when using simple optimization
+            simple_optimization_objectives.append(cp.square(ingredient_quantities[index] - initial_estimate))
+            if total is not None:
+                initial_estimates.append(initial_estimate)
 
-            ingredient_id = ingredient.get("id", "")
-            
-            # Add constraint for flavour ingredients and food additives, except for first product ingredient
-            if constraints is not None and not is_first_product_ingredient:
-                if "flavour" in ingredient_id or (ingredient_id.startswith("en:e") and len(ingredient_id) > 4 and ingredient_id[4].isdigit()):
-                    constraints.append(ingredient_quantities[index] <= 2.0)
-
-            # If we are certain the ingredient contains a minimum amount of salt, sugar or fat
-            # we add it to the expressions so that we can add constraints to keep the total below the product's nutritional information
-            if ingredient_id == 'en:salt' or ingredient_id.endswith('-salt'):
-                expressions['salt'] += ingredient_quantities[index]
-            elif ingredient_id == 'en:sugar' or ingredient_id.endswith('-sugar'):
-                expressions['sugars'] += ingredient_quantities[index]
-            elif ingredient_id == 'en:honey' or ingredient_id.endswith('-honey'):
-                expressions['sugars'] += 0.6 * ingredient_quantities[index]
-            elif ingredient_id.endswith('-oil') or ingredient_id == 'en:cocoa-butter':
-                expressions['fat'] += ingredient_quantities[index]
-            elif ingredient_id.endswith('-fat'):
-                expressions['fat'] += 0.8 * ingredient_quantities[index]
-            elif ingredient_id == 'en:butter':
-                expressions['fat'] += 0.8 * ingredient_quantities[index]
-            elif ingredient_id == 'en:butterfat':
-                expressions['fat'] += 0.9 * ingredient_quantities[index]
-            
             index += 1
-
-    # If we are at the top level and we have nutritional information for the product
-    # we add constraints to keep the total salt, sugar and fat below the product's nutritional information
-    # We do this because processing (e.g. evaporation) should not reduce the total amount of salt, sugar or fat in the product
-    if is_top_level and constraints is not None and product_nutrients is not None:
-        salt = product_nutrients.get('salt_100g')
-        if salt is not None:
-            constraints.append(expressions['salt'] <= ensure_float(salt))
-
-        sugars = product_nutrients.get('sugars_100g')
-        if sugars is not None:
-            constraints.append(expressions['sugars'] <= ensure_float(sugars))
-
-        fat = product_nutrients.get('fat_100g')
-        if fat is not None:
-            constraints.append(expressions['fat'] <= ensure_float(fat))
 
     return index, percent_unknown
 
@@ -246,8 +256,6 @@ def estimate_recipe(product, use_simple_estimates=False):
     recipe_estimator = product["recipe_estimator"]
     nutrients = recipe_estimator["nutrients"]
 
-    ingredients_nutrients = []
-    product_nutrients = []
     leaf_ingredients = []
     water_proportions = []
 
@@ -257,6 +265,7 @@ def estimate_recipe(product, use_simple_estimates=False):
     ingredient_vars = []
     add_ingredient_constraints(
         ingredients,
+        nutrients,
         constraints,
         leaf_ingredients,
         ingredient_quantities,
@@ -270,40 +279,12 @@ def estimate_recipe(product, use_simple_estimates=False):
         <= 100
     )
 
-    for nutrient_key in nutrients:
-        nutrient = nutrients[nutrient_key]
-
-        weighting = nutrient.get("weighting", 0)
-        # Skip nutrients that don't have a weighting
-        if weighting == 0:
-            continue
-
-        product_total = nutrient["product_total"]
-        product_nutrients.append(product_total)
-        nutrient_weightings.append(weighting)
-        ingredient_nutrients = []
-
-        for i, ingredient in enumerate(leaf_ingredients):
-            ingredient_nutrient = ingredient["nutrients"].get(nutrient_key, {})
-            ingredient_nutrient_percent = ingredient_nutrient.get("percent_nom", 0)
-            ingredient_nutrients.append(ingredient_nutrient_percent * 0.01)
-
-        ingredients_nutrients.append(ingredient_nutrients)
-        
-        # Tried adding a constraint that the minimum nutrient value for all ingredients can't exceed what is on the packaging
-        # but it didn't improve the results
-    
-    # Need an np.array in the matrix multiplication below
-    ingredients_nutrients = np.array(ingredients_nutrients)
-
     # Pass 1A: Run estimate_percentages to get initial estimates for the ingredient quantities and objectives
     # Initial estimates are based on a power-law series.
-    nutrient_objectives1 = []
     simple_objectives1 = []
-    simple_estimates1 = []
-    _, _ = estimate_percentages(
-        ingredient_quantities, nutrient_objectives1, simple_objectives1, ingredients, simple_estimates1,
-        constraints=constraints, product_nutrients=product.get('nutriments', {})
+    initial_estimates = []
+    estimate_percentages(
+        ingredient_quantities, [], simple_objectives1, ingredients, initial_estimates
     )
 
     # Pass 1B: Run the solver with simple objectives
@@ -315,55 +296,73 @@ def estimate_recipe(product, use_simple_estimates=False):
     prob1 = cp.Problem(cp.Minimize(sum(objectives1)), constraints)
     prob1.solve()
 
-    pass1_solution = ingredient_quantities.value if prob1.status == cp.OPTIMAL else simple_estimates1
+    pass1_solution = ingredient_quantities.value if prob1.status == cp.OPTIMAL else initial_estimates
 
     # Pass 2A: Run estimate_percentages again to get updated objectives + new percent unknown based on the solution from pass 1B (if we have one)
 
-    nutrient_objectives2 = []
-    simple_objectives2 = []
-    simple_estimates2 = []
-
-    custom_estimates = pass1_solution if pass1_solution is not None else None
-
-    _, percent_unknown2 = estimate_percentages(
-        ingredient_quantities, nutrient_objectives2, simple_objectives2, ingredients, simple_estimates2,
-        custom_estimates=custom_estimates,
-        constraints=constraints, product_nutrients=product.get('nutriments', {})
+    nutrient_objectives = []
+    _, percent_unknown = estimate_percentages(
+        ingredient_quantities, nutrient_objectives, [], ingredients, pass1_solution, total=None
     )
 
     # Pass 2B (optional): If we have nutrient information for the product and the ingredients,
     # and if the percent unknown is low, then we try to solve with nutrient objectives
 
-    try_nutrients = False if use_simple_estimates else (percent_unknown2 < 10 and len(leaf_ingredients[0]["nutrients"]))
+    try_nutrients = False if use_simple_estimates else (percent_unknown < 10 and len(leaf_ingredients[0]["nutrients"]))
 
     final_solution = pass1_solution
     final_prob = prob1
     nutrient_variance_value = None
+    
+    product_nutrients = []
+    if try_nutrients:
+        # Gather ingredient nutrient quantities to an objective to minimize nutrient variance
+        ingredients_nutrients = []
+        for nutrient_key in nutrients:
+            nutrient = nutrients[nutrient_key]
 
-    if try_nutrients and product_nutrients:
-        residual = ingredients_nutrients @ ingredient_quantities - product_nutrients
-        nutrient_variance = cp.sum(nutrient_weightings @ cp.square(residual))
-        nutrient_objectives2.append(nutrient_variance)
+            weighting = nutrient.get("weighting", 0)
+            # Skip nutrients that don't have a weighting
+            if weighting == 0:
+                continue
 
-        objectives2 = list(nutrient_objectives2)
-        objectives2.append(evaporation_cost)
+            product_total = nutrient["product_total"]
+            product_nutrients.append(product_total)
+            nutrient_weightings.append(weighting)
+            ingredient_nutrients = []
 
-        prob2 = cp.Problem(cp.Minimize(sum(objectives2)), constraints)
-        prob2.solve()
+            for i, ingredient in enumerate(leaf_ingredients):
+                ingredient_nutrient = ingredient["nutrients"].get(nutrient_key, {})
+                ingredient_nutrient_percent = ingredient_nutrient.get("percent_nom", 0)
+                ingredient_nutrients.append(ingredient_nutrient_percent * 0.01)
 
-        if prob2.status == cp.OPTIMAL:
-            nutrient_variance_value = nutrient_variance.value.item()
-            recipe_estimator["nutrient_variance"] = nutrient_variance_value
+            ingredients_nutrients.append(ingredient_nutrients)
+            
+            # Tried adding a constraint that the minimum nutrient value for all ingredients can't exceed what is on the packaging
+            # but it didn't improve the results
+        
+        # Only do nutrient optimization if we have at least one product nutrient with a weighting
+        if product_nutrients:
+            # Need an np.array in the matrix multiplication below
+            ingredients_nutrients = np.array(ingredients_nutrients)
 
-            if nutrient_variance_value <= 2500:
-                final_solution = ingredient_quantities.value
-                final_prob = prob2
-            else:
-                final_solution = pass1_solution
-                final_prob = prob1
-        else:
-            final_solution = pass1_solution
-            final_prob = prob1
+            residual = ingredients_nutrients @ ingredient_quantities - product_nutrients
+            nutrient_variance = cp.sum(nutrient_weightings @ cp.square(residual))
+            nutrient_objectives.append(nutrient_variance)
+
+            objectives2 = list(nutrient_objectives)
+            objectives2.append(evaporation_cost)
+
+            prob2 = cp.Problem(cp.Minimize(sum(objectives2)), constraints)
+            prob2.solve()
+
+            if prob2.status == cp.OPTIMAL:
+                nutrient_variance_value = nutrient_variance.value.item()
+                recipe_estimator["nutrient_variance"] = nutrient_variance_value
+
+                if nutrient_variance_value <= 2500:
+                    final_solution = ingredient_quantities.value
+                    final_prob = prob2
 
     if try_nutrients and product_nutrients and final_prob is prob1 and prob1.status == cp.OPTIMAL:
         product_nutrients_arr = np.array(product_nutrients)

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -190,17 +190,14 @@ def estimate_percentages(
         salt = nutriments.get('salt_100g')
         if salt is not None:
             constraints.append(expressions['salt'] <= ensure_float(salt))
-            print(f"Adding constraint: salt <= {salt}")
 
         sugars = nutriments.get('sugars_100g')
         if sugars is not None:
             constraints.append(expressions['sugars'] <= ensure_float(sugars))
-            print(f"Adding constraint: sugars <= {sugars}")
 
         fat = nutriments.get('fat_100g')
         if fat is not None:
             constraints.append(expressions['fat'] <= ensure_float(fat))
-            print(f"Adding constraint: fat <= {fat}")
 
     return index, percent_unknown
 

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -5,6 +5,7 @@ import numpy as np
 from .fitness import get_objective_function_args, objective as objective_function
 
 from .prepare_nutrients import prepare_nutrients
+from .nutrients import ensure_float
 
 POWER = -1.7
 EVAPORATION_COST = 0.01
@@ -107,7 +108,7 @@ def add_ingredient_constraints(
 
 
 def estimate_percentages(
-    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown = 0
+    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown=0, constraints=None, nutriments=None, is_first_product_ingredient=True, expressions=None
 ):
     # Each ingredient quantity = a * n ^ p
     # where p is the POWER constant, n is the ingredient number and a is the percentage of the first ingredient
@@ -115,6 +116,14 @@ def estimate_percentages(
     num_ingredients = len(ingredients)
     if num_ingredients < 1:
         return 0, 100
+
+    is_top_level = expressions is None
+    if is_top_level:
+        expressions = {
+            'salt': cp.Constant(0),
+            'sugars': cp.Constant(0),
+            'fat': cp.Constant(0),
+        }
 
     raw_sum = sum([(n + 1.0) ** POWER for n in range(num_ingredients)])
     a = total / raw_sum
@@ -130,7 +139,11 @@ def estimate_percentages(
                 simple_estimates,
                 estimate,
                 index,
-                percent_unknown
+                percent_unknown,
+                constraints,
+                nutriments,
+                is_first_product_ingredient and n == 0,
+                expressions
             )
         else:
             # If ingredient has no nutrient information then add an objective to keep close to the estimate
@@ -143,7 +156,51 @@ def estimate_percentages(
             # Simple objectives are used if we find that going by nutrients doesn't work
             simple_objectives.append(cp.square(ingredient_quantities[index] - estimate))
             simple_estimates.append(estimate)
+
+            ingredient_id = ingredient.get("id", "")
+            
+            # Add constraint for flavour ingredients and food additives, except for first product ingredient
+            if constraints is not None and not is_first_product_ingredient:
+                if "flavour" in ingredient_id or (ingredient_id.startswith("en:e") and len(ingredient_id) > 4 and ingredient_id[4].isdigit()):
+                    constraints.append(ingredient_quantities[index] <= 2.0)
+
+            # If we are certain the ingredient contains a minimum amount of salt, sugar or fat
+            # we add it to the expressions so that we can add constraints to keep the total below the product's nutritional information
+            if ingredient_id == 'en:salt' or ingredient_id.endswith('-salt'):
+                expressions['salt'] += ingredient_quantities[index]
+            elif ingredient_id == 'en:sugar' or ingredient_id.endswith('-sugar'):
+                expressions['sugars'] += ingredient_quantities[index]
+            elif ingredient_id == 'en:honey' or ingredient_id.endswith('-honey'):
+                expressions['sugars'] += 0.6 * ingredient_quantities[index]
+            elif ingredient_id.endswith('-oil') or ingredient_id == 'en:cocoa-butter':
+                expressions['fat'] += ingredient_quantities[index]
+            elif ingredient_id.endswith('-fat'):
+                expressions['fat'] += 0.8 * ingredient_quantities[index]
+            elif ingredient_id == 'en:butter':
+                expressions['fat'] += 0.8 * ingredient_quantities[index]
+            elif ingredient_id == 'en:butterfat':
+                expressions['fat'] += 0.9 * ingredient_quantities[index]
+            
             index += 1
+
+    # If we are at the top level and we have nutritional information for the product
+    # we add constraints to keep the total salt, sugar and fat below the product's nutritional information
+    # We do this because processing (e.g. evaporation) should not reduce the total amount of salt, sugar or fat in the product
+    if is_top_level and constraints is not None and nutriments is not None:
+        salt = nutriments.get('salt_100g')
+        if salt is not None:
+            constraints.append(expressions['salt'] <= ensure_float(salt))
+            print(f"Adding constraint: salt <= {salt}")
+
+        sugars = nutriments.get('sugars_100g')
+        if sugars is not None:
+            constraints.append(expressions['sugars'] <= ensure_float(sugars))
+            print(f"Adding constraint: sugars <= {sugars}")
+
+        fat = nutriments.get('fat_100g')
+        if fat is not None:
+            constraints.append(expressions['fat'] <= ensure_float(fat))
+            print(f"Adding constraint: fat <= {fat}")
 
     return index, percent_unknown
 
@@ -242,7 +299,7 @@ def estimate_recipe(product, use_simple_estimates=False):
 
     # Add objective to keep unknown ingredients close to the inverse power series
     # simple_objectives does this for all ingredients
-    _, percent_unknown = estimate_percentages(ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates)
+    _, percent_unknown = estimate_percentages(ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, constraints=constraints, nutriments=product.get('nutriments', {}))
 
     # Main objective to match ingredient nutrients to product nutrients
     if product_nutrients:

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -108,7 +108,7 @@ def add_ingredient_constraints(
 
 
 def estimate_percentages(
-    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown=0, constraints=None, nutriments=None, is_first_product_ingredient=True, expressions=None
+    ingredient_quantities, nutrient_objectives, simple_objectives, ingredients, simple_estimates, total=100.0, index=0, percent_unknown=0, constraints=None, product_nutrients=None, is_first_product_ingredient=True, expressions=None
 ):
     # Each ingredient quantity = a * n ^ p
     # where p is the POWER constant, n is the ingredient number and a is the percentage of the first ingredient

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -180,7 +180,7 @@ def set_percentages(solution_x, ingredient_vars, product_total_quantity):
     return index, total_mixing_bowl_quantity, total_original_quantity
 
 
-def estimate_recipe(product):
+def estimate_recipe(product, use_simple_estimates=False):
     current = time.perf_counter()
     leaf_ingredient_count = prepare_nutrients(product, True)
     ingredients = product["ingredients"]
@@ -254,7 +254,7 @@ def estimate_recipe(product):
         # the ingredient nutrients are greater than the product nutrients
         # But it didn't offer any significant improvement
 
-    try_nutrients = percent_unknown < 10 and len(leaf_ingredients[0]["nutrients"])
+    try_nutrients = False if use_simple_estimates else (percent_unknown < 10 and len(leaf_ingredients[0]["nutrients"]))
 
     # Don't bother with the nutrient approach if the first ingredient is unknown or too many others are unknown
     objectives = nutrient_objectives if try_nutrients else simple_objectives

--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -144,15 +144,15 @@ def add_ingredient_constraints(
     # we add constraints to keep the total salt, sugar and fat below the product's nutritional information
     # We do this because processing (e.g. evaporation) should not reduce the total amount of salt, sugar or fat in the product
     if is_top_level and constraints is not None and nutrients is not None:
-        salt = nutrients.get('salt')
+        salt = nutrients.get('salt',{}).get('product_total')
         if salt is not None:
             constraints.append(nutrients_from_ingredients['salt'] <= ensure_float(salt))
 
-        sugars = nutrients.get('sugars')
+        sugars = nutrients.get('sugars',{}).get('product_total')
         if sugars is not None:
             constraints.append(nutrients_from_ingredients['sugars'] <= ensure_float(sugars))
 
-        fat = nutrients.get('fat')
+        fat = nutrients.get('fat',{}).get('product_total')
         if fat is not None:
             constraints.append(nutrients_from_ingredients['fat'] <= ensure_float(fat))
 


### PR DESCRIPTION
This PR changes the simple estimates and objectives estimation for cvxpy:
- flavours and additives are capped at 2% (unless they are the first ingredient, as some products are just the additive)
- maximum limit for ingredients that have a known minimum content of salt / sugars / fat (e.g. "sugar" is almost 100% sugars). Those constraints are similar to the ones that are in the glop estimator.

At this point, those constraints are not applied to the full estimation with nutrients (so we could still get a value for an ingredient "salt" that is higher than the salt nutrition fact for the product).
[@stephanegigandet I don't think this is correct. You are using the constraints in the full estimation too]

But they do influence the full estimation still:
- the full estimation has an objective to be close to the simple estimates
- the simple estimates may result in a lower amount of ingredients with unknown nutrients (e.g. lower amount of additives), which may trigger the full estimate to be used more.

Results are improved:

- simple algorithm average difference goes from 23.71 to 23.38 (better than full cvxpy)
- cvxpy algorithm average difference goes from 23.55 to 23.45

We could also try adding those constraints to the full algorithms to make them hard constraints.