### PR TITLE
fix: add a hard constraint in cvxpy to have at least 100g of ingredients

### DIFF
--- a/recipe_estimator/recipe_estimator_cvxpy.py
+++ b/recipe_estimator/recipe_estimator_cvxpy.py
@@ -273,6 +273,11 @@ def estimate_recipe(product, use_simple_estimates=False):
         ingredient_vars,
     )
 
+    # Hard constraint: sum of ingredients must be at least 100g
+    constraints.append(
+        cp.sum(ingredient_quantities) >= 100
+    )
+
     # Hard constraint: sum of ingredients less maximum water loss can't be greater than 100g
     constraints.append(
         cp.sum(ingredient_quantities) - (ingredient_quantities @ water_proportions)

--- a/recipe_estimator/recipe_estimator_cvxpy_test.py
+++ b/recipe_estimator/recipe_estimator_cvxpy_test.py
@@ -82,3 +82,30 @@ def test_estimate_recipe_subingredient_limits():
     proteins = product['ingredients'][1]
     # Percent estimate is as high a possible
     assert abs(50 - proteins.get('percent_estimate')) < 2
+
+
+def test_ingredients_sum_to_at_least_100():
+    product = {
+        'code': 'test',
+        'ingredients': [
+            {
+                'id':'A',
+                'nutrients': {
+                    'fiber': {'percent_nom': 15, 'percent_min': 15, 'percent_max': 15},
+                }
+            },
+            {
+                'id':'B',
+                'nutrients': {
+                    'fiber': {'percent_nom': 10, 'percent_min': 10, 'percent_max': 10},
+                }
+            }
+        ],
+        'nutriments': {
+            'fiber_100g': 10,
+        }}
+
+    estimate_recipe(product)
+
+    total_quantity = sum(ingredient['quantity_estimate'] for ingredient in product['ingredients'])
+    assert total_quantity >= 100


### PR DESCRIPTION
I was looking at this product: https://fr.openfoodfacts.org/cgi/test_ingredients_analysis.pl?target_lc=fr&ingredients_text=Poitrine+de+porc%2C+sel%2C+conservateurs+%3A+lactate+de+potassium%2C+ac%C3%A9tate+de+potassium+%3B+ar%C3%B4me+naturel+%28pr%C3%A9sence+naturelle+de+polyph%C3%A9nols%29%2C+antioxydant+%3A+acide+ascorbique.&type=add&lc=fr&action=process&estimator=recipe_estimator_cvxpy&fat=19&saturated-fat=7&carbohydrates=0&sugars=0&fiber=0&proteins=17&salt=2.205&submit=Envoyer

which has about 90g of estimated ingredients:

<img width="1003" height="210" alt="image" src="https://github.com/user-attachments/assets/c6c35821-a03e-418d-bc93-76734d765597" />

There is a constraint to have at least 100g of ingredients in scipy, but not for cvxpy. This PR adds it.

Initially I had worse results on the fr-1000 test set. I investigated the products with the biggest differences, and found a lot had clear data issues, resulting in an ingredient structure with known percent that were impossible. (e.g. the very last ingredient of a product with a known % of 70%).

I changed the metrics so that impossible products are skipped: https://github.com/openfoodfacts/recipe-estimator-metrics/pull/25

With those new metrics, on the fr-1000 set (with 175 products skipped).

Without the sum ingredients >= 100 constraint:

Average difference: 17.65

With the sum ingredients >= 100 constraint:

Average difference: 16.1
